### PR TITLE
feat(import): Add tables aiding storage of import data

### DIFF
--- a/migrations/import/down.sql
+++ b/migrations/import/down.sql
@@ -7,7 +7,7 @@ DROP TABLE IF EXISTS bookbrainz.publisher_import;
 DROP TABLE IF EXISTS bookbrainz.work_import;
 DROP TABLE IF EXISTS bookbrainz.discard_votes;
 DROP TABLE IF EXISTS bookbrainz.link_import;
-DROP TABLE IF EXISTS bookbrainz.origin_import;
+DROP TABLE IF EXISTS bookbrainz.origin_source;
 DROP TABLE IF EXISTS bookbrainz.import;
 
 COMMIT;

--- a/migrations/import/down.sql
+++ b/migrations/import/down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DROP TABLE IF EXISTS bookbrainz.creator_import;
+DROP TABLE IF EXISTS bookbrainz.edition_import;
+DROP TABLE IF EXISTS bookbrainz.publication_import;
+DROP TABLE IF EXISTS bookbrainz.publisher_import;
+DROP TABLE IF EXISTS bookbrainz.work_import;
+DROP TABLE IF EXISTS bookbrainz.discard_votes;
+DROP TABLE IF EXISTS bookbrainz.link_import;
+DROP TABLE IF EXISTS bookbrainz.origin_import;
+DROP TABLE IF EXISTS bookbrainz.import;
+
+COMMIT;

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -58,7 +58,7 @@ ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES book
 -- Table to store all origin sources of imported data
 CREATE TABLE IF NOT EXISTS bookbrainz.origin_source (
     id SERIAL PRIMARY KEY,
-    value TEXT NOT NULL CHECK (value <> '')
+    name TEXT NOT NULL CHECK (name <> '')
 );
 
 -- Table to store source metadata linked with import and (upon it's subsequent upgrade) with entity

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -1,0 +1,81 @@
+BEGIN;
+
+-- Base table for imports storing import ids and types
+CREATE TABLE IF NOT EXISTS bookbrainz.import (
+    id SERIAL PRIMARY KEY,
+    type bookbrainz.entity_type NOT NULL
+);
+
+-- Tables linking import and relevant data in entitytype_data tables
+CREATE TABLE IF NOT EXISTS bookbrainz.creator_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.creator_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.edition_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.edition_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.publication_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publication_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.publisher_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publisher_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.work_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.work_data (id);
+
+-- Table to store votes cast to discard an import
+CREATE TABLE IF NOT EXISTS bookbrainz.discard_votes (
+    id SERIAL PRIMARY KEY,
+    import_id INT NOT NULL,
+    editor_id INT NOT NULL,
+    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now())
+);
+ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);
+
+-- Table to store all origin sources of imported data
+CREATE TABLE IF NOT EXISTS bookbrainz.origin_import (
+    id SERIAL PRIMARY KEY,
+    value TEXT NOT NULL CHECK (value <> '')
+);
+
+-- Table to store source metadata linked with import and (upon it's subsequent upgrade) with entity
+-- The origin_name_id refers to the source of the import, a foreign key reference to origin_import
+-- The origin_id is the designated id of the import data item at it's source
+CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
+    import_id INT,
+    origin_name_id INT NOT NULL,
+    origin_id TEXT NOT NULL CHECK (origin_id <> ''),
+    imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+    last_edited VARCHAR(10),
+    entity_id UUID DEFAULT NULL,
+    metadata jsonb,
+    PRIMARY KEY (
+        origin_name_id,
+        origin_id
+    )
+);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (entity_id) REFERENCES bookbrainz.entity (bbid);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_import (id);
+
+COMMIT;

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     origin_source_id INT NOT NULL,
     origin_id TEXT NOT NULL CHECK (origin_id <> ''),
     imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-    last_edited DATE,
+    last_edited TIMESTAMP WITHOUT TIME ZONE,
     entity_id UUID DEFAULT NULL,
     import_metadata jsonb,
     CHECK (

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -56,7 +56,7 @@ ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (import_id) REFERENCES book
 ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);
 
 -- Table to store all origin sources of imported data
-CREATE TABLE IF NOT EXISTS bookbrainz.origin_import (
+CREATE TABLE IF NOT EXISTS bookbrainz.origin_source (
     id SERIAL PRIMARY KEY,
     value TEXT NOT NULL CHECK (value <> '')
 );
@@ -79,6 +79,6 @@ CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
 );
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (entity_id) REFERENCES bookbrainz.entity (bbid);
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
-ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_import (id);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_source (id);
 
 COMMIT;

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -69,9 +69,9 @@ CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     origin_source_id INT NOT NULL,
     origin_id TEXT NOT NULL CHECK (origin_id <> ''),
     imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-    last_edited VARCHAR(10),
+    last_edited DATE,
     entity_id UUID DEFAULT NULL,
-    metadata jsonb,
+    import_metadata jsonb,
     PRIMARY KEY (
         origin_source_id,
         origin_id

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -72,6 +72,11 @@ CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     last_edited DATE,
     entity_id UUID DEFAULT NULL,
     import_metadata jsonb,
+    CHECK (
+            ((import_id IS NULL) AND NOT (entity_id IS NULL))
+        OR
+            (NOT (import_id IS NULL) and (entity_id IS NULL))
+    ),
     PRIMARY KEY (
         origin_source_id,
         origin_id

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -44,10 +44,13 @@ ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (data_id) REFERENCES bookbrai
 
 -- Table to store votes cast to discard an import
 CREATE TABLE IF NOT EXISTS bookbrainz.discard_votes (
-    id SERIAL PRIMARY KEY,
     import_id INT NOT NULL,
     editor_id INT NOT NULL,
-    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now())
+    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+    PRIMARY KEY (
+        import_id,
+        editor_id
+    )
 );
 ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -9,35 +9,35 @@ CREATE TABLE IF NOT EXISTS bookbrainz.import (
 -- Tables linking import and relevant data in entitytype_data tables
 CREATE TABLE IF NOT EXISTS bookbrainz.creator_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.creator_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.edition_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.edition_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.publication_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publication_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.publisher_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publisher_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.work_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.work_data (id);

--- a/migrations/import/up.sql
+++ b/migrations/import/up.sql
@@ -62,23 +62,23 @@ CREATE TABLE IF NOT EXISTS bookbrainz.origin_source (
 );
 
 -- Table to store source metadata linked with import and (upon it's subsequent upgrade) with entity
--- The origin_name_id refers to the source of the import, a foreign key reference to origin_import
+-- The origin_source_id refers to the source of the import, a foreign key reference to origin_import
 -- The origin_id is the designated id of the import data item at it's source
 CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     import_id INT,
-    origin_name_id INT NOT NULL,
+    origin_source_id INT NOT NULL,
     origin_id TEXT NOT NULL CHECK (origin_id <> ''),
     imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
     last_edited VARCHAR(10),
     entity_id UUID DEFAULT NULL,
     metadata jsonb,
     PRIMARY KEY (
-        origin_name_id,
+        origin_source_id,
         origin_id
     )
 );
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (entity_id) REFERENCES bookbrainz.entity (bbid);
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
-ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_source (id);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_source_id) REFERENCES bookbrainz.origin_source (id);
 
 COMMIT;

--- a/schemas/bookbrainz.sql
+++ b/schemas/bookbrainz.sql
@@ -610,6 +610,77 @@ CREATE TABLE bookbrainz._editor_entity_visits (
 ALTER TABLE bookbrainz._editor_entity_visits ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);
 ALTER TABLE bookbrainz._editor_entity_visits ADD FOREIGN KEY (bbid) REFERENCES bookbrainz.entity (bbid);
 
+CREATE TABLE IF NOT EXISTS bookbrainz.import (
+    id SERIAL PRIMARY KEY,
+    type bookbrainz.entity_type NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.creator_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.creator_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.edition_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.edition_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.publication_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publication_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.publisher_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publisher_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.work_import (
+	import_id INT PRIMARY KEY,
+	data_id INT
+);
+ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.work_data (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.discard_votes (
+    id SERIAL PRIMARY KEY,
+    import_id INT NOT NULL,
+    editor_id INT NOT NULL,
+    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now())
+);
+ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.origin_import (
+    id SERIAL PRIMARY KEY,
+    value TEXT NOT NULL CHECK (value <> '')
+);
+
+CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
+    import_id INT,
+    origin_name_id INT NOT NULL,
+    origin_id TEXT NOT NULL CHECK (origin_id <> ''),
+    imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+    last_edited VARCHAR(10),
+    entity_id UUID DEFAULT NULL,
+    metadata jsonb,
+    PRIMARY KEY (
+        origin_name_id,
+        origin_id
+    )
+);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (entity_id) REFERENCES bookbrainz.entity (bbid);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_import (id);
+
 -- Views --
 
 CREATE VIEW bookbrainz.creator AS

--- a/schemas/bookbrainz.sql
+++ b/schemas/bookbrainz.sql
@@ -672,7 +672,7 @@ CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     origin_source_id INT NOT NULL,
     origin_id TEXT NOT NULL CHECK (origin_id <> ''),
     imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-    last_edited DATE,
+    last_edited TIMESTAMP WITHOUT TIME ZONE,
     entity_id UUID DEFAULT NULL,
     import_metadata jsonb,
     CHECK (

--- a/schemas/bookbrainz.sql
+++ b/schemas/bookbrainz.sql
@@ -617,69 +617,77 @@ CREATE TABLE IF NOT EXISTS bookbrainz.import (
 
 CREATE TABLE IF NOT EXISTS bookbrainz.creator_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.creator_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.creator_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.edition_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.edition_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.edition_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.publication_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.publication_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publication_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.publisher_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.publisher_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.publisher_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.work_import (
 	import_id INT PRIMARY KEY,
-	data_id INT
+	data_id INT NOT NULL
 );
 ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.work_import ADD FOREIGN KEY (data_id) REFERENCES bookbrainz.work_data (id);
 
 CREATE TABLE IF NOT EXISTS bookbrainz.discard_votes (
-    id SERIAL PRIMARY KEY,
     import_id INT NOT NULL,
     editor_id INT NOT NULL,
-    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now())
+    voted_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+    PRIMARY KEY (
+        import_id,
+        editor_id
+    )
 );
 ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
 ALTER TABLE bookbrainz.discard_votes ADD FOREIGN KEY (editor_id) REFERENCES bookbrainz.editor (id);
 
-CREATE TABLE IF NOT EXISTS bookbrainz.origin_import (
+CREATE TABLE IF NOT EXISTS bookbrainz.origin_source (
     id SERIAL PRIMARY KEY,
-    value TEXT NOT NULL CHECK (value <> '')
+    name TEXT NOT NULL CHECK (name <> '')
 );
 
 CREATE TABLE IF NOT EXISTS bookbrainz.link_import (
     import_id INT,
-    origin_name_id INT NOT NULL,
+    origin_source_id INT NOT NULL,
     origin_id TEXT NOT NULL CHECK (origin_id <> ''),
     imported_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-    last_edited VARCHAR(10),
+    last_edited DATE,
     entity_id UUID DEFAULT NULL,
-    metadata jsonb,
+    import_metadata jsonb,
+    CHECK (
+            ((import_id IS NULL) AND NOT (entity_id IS NULL))
+        OR
+            (NOT (import_id IS NULL) and (entity_id IS NULL))
+    ),
     PRIMARY KEY (
-        origin_name_id,
+        origin_source_id,
         origin_id
     )
 );
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (entity_id) REFERENCES bookbrainz.entity (bbid);
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbrainz.import (id);
-ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_name_id) REFERENCES bookbrainz.origin_import (id);
+ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_source_id) REFERENCES bookbrainz.origin_source (id);
 
 -- Views --
 


### PR DESCRIPTION
feat(schema/bookbrainz): Add tables aiding storage of import data

* Base table for imports storing import ids and types
        + bookbrainz.import
* Tables linking import and relevant data in entitytype_data tables
        + bookbrainz.creator_import
* Tables linking import and relevant data in entitytype_data tables
        + bookbrainz.creator_import
        + bookbrainz.editor_import
        + bookbrainz.publication_import
        + bookbrainz.publisher_import
        + bookbrainz.work_import
* Table to store votes cast to discard an import
        + bookbrainz.discard_votes
* Table to store all origin sources of imported data
        + bookbrainz.origin_import
* Table to store source metadata linked with import and (upon it's subsequent
    upgrade) with entity. The origin_name_id refers to the source of the import,
    a foreign key reference to origin_import. The origin_id is the designated
    id of the import data item at it's source.
    	+ bookbrainz.link_import